### PR TITLE
Finished Implementation of local XML Data storage via SharedPreference

### DIFF
--- a/app/src/main/java/com/rafaelmardom/movies_and_shows_api/data/MovieDataRepository.kt
+++ b/app/src/main/java/com/rafaelmardom/movies_and_shows_api/data/MovieDataRepository.kt
@@ -1,29 +1,30 @@
 package com.rafaelmardom.movies_and_shows_api.data
 
+import android.util.Log
+import com.rafaelmardom.movies_and_shows_api.data.local.MovieLocalDataSource
 import com.rafaelmardom.movies_and_shows_api.data.remote.MovieRemoteDataSource
 import com.rafaelmardom.movies_and_shows_api.domain.Movie
 import com.rafaelmardom.movies_and_shows_api.domain.MovieRepository
 
 class MovieDataRepository(
-    // private val localSource: MovieLocalDataSource,
+    private val localSource: MovieLocalDataSource,
     private val remoteSource: MovieRemoteDataSource
 ) : MovieRepository{
 
     override fun getAll(): List<Movie> {
-        // ONLY REMOTE YET --> Change when Local Data is finished
-        /*
-        return if (localSource.getMovies().isNotEmpty()){
-            localSource.getMovies()
+
+        if (localSource.getAll().isNotEmpty()){
+            Log.d("@dev", "Local")
+            return localSource.getAll()
         }else{
-            remoteSource.getMovies()
+            Log.d("@dev", "Remote")
+            var remoteList = remoteSource.getAll()
+            localSource.saveAll(remoteList)
+            return remoteList
         }
-        */
-        return remoteSource.getAll()
     }
 
     override fun getById(movieId: String): Movie? {
-        // ONLY REMOTE YET --> Change when Local Data is finished
-        // return localSource.getMovieById(movieId) ?: remoteSource.getMovieById(movieId)
-        return remoteSource.getById(movieId)
+        return localSource.getById(movieId) ?: remoteSource.getById(movieId)
     }
 }

--- a/app/src/main/java/com/rafaelmardom/movies_and_shows_api/data/local/MovieLocalDataSource.kt
+++ b/app/src/main/java/com/rafaelmardom/movies_and_shows_api/data/local/MovieLocalDataSource.kt
@@ -1,0 +1,9 @@
+package com.rafaelmardom.movies_and_shows_api.data.local
+
+import com.rafaelmardom.movies_and_shows_api.domain.Movie
+
+interface MovieLocalDataSource {
+    fun getAll(): List<Movie>
+    fun getById(movieId: String): Movie?
+    fun saveAll(moviesList: List<Movie>)
+}

--- a/app/src/main/java/com/rafaelmardom/movies_and_shows_api/data/local/xml/MovieXmlLocalDataSource.kt
+++ b/app/src/main/java/com/rafaelmardom/movies_and_shows_api/data/local/xml/MovieXmlLocalDataSource.kt
@@ -1,0 +1,38 @@
+package com.rafaelmardom.movies_and_shows_api.data.local.xml
+
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import com.rafaelmardom.movies_and_shows_api.data.local.MovieLocalDataSource
+import com.rafaelmardom.movies_and_shows_api.domain.Movie
+
+class MovieXmlLocalDataSource (
+    private val sharedPreferences: SharedPreferences,
+    // private val serializer: KSerializer // yet to implement
+) : MovieLocalDataSource{
+
+    private val editor = sharedPreferences.edit()
+    private val gson = Gson()
+
+    override fun getAll(): List<Movie> {
+        val movies = mutableListOf<Movie>()
+        sharedPreferences.all.forEach {
+            editor.apply {
+                movies.add(gson.fromJson(it.value as String, Movie::class.java))
+            }.apply()
+        }
+        return movies
+
+    }
+
+    override fun getById(movieId: String): Movie? =
+        sharedPreferences.getString(movieId, null).let{
+            gson.fromJson(it, Movie::class.java)
+        }
+
+    override fun saveAll(moviesList: List<Movie>) {
+        moviesList.forEach {
+            editor.putString(it.id, gson.toJson(it, Movie::class.java))
+        }
+        editor.apply()
+    }
+}


### PR DESCRIPTION
## Description de la tarea
<!-- Descripción sobre lo que se pide en la tarea -->
Implementation of local XML data storage via Shared Preference using Gson dependencies to make Json conversions (Kserializer yet to implement).

## ¿Cómo se ha implementado?
<!-- Estructura de clases, patrones: MVVM, etc.  -->
Created a package called local inside of data package layer with:

- MovieLocalDataSource: Interface that fits the same job as MovieRepository does in domain, but in local.

- MovieXmlLocalDataSource: Class that inherits from MovieLocalDataSource and receives a SharedPreferences object as parameter (it should receive a KSerializer object too but it's not implemented yet) and uses gson converter to save data into / get info from a XML file.

- MovieDataRepository: This class already existed from past branches, but now receives both a local and a remote Source as parameters in order to obtain data. I tweaked the functions in this class: now the app will search first in local storage. If no data is found, the app will try it from a remote source and save it into local storage.

## Keywords
<!-- Palabras relacionadas con los conceptos vistos -->
Local, Data Storage, Gson, Serialization, XML, SharedPreferences, Data Treatment, Data Sources...

## Screenshots or Video
<!-- Captura de pantalla de la consola -->
In order to test the code and MovieDataRepository changes, I used Retrofit implementation from past commits as a remote Source.

Test used
![image](https://user-images.githubusercontent.com/104196849/201158141-97f3abe3-a0a9-4118-b467-6801de7c8eaf.png)
![image](https://user-images.githubusercontent.com/104196849/201158059-3f6d189a-fa24-47c4-9639-762e8862a40b.png)

## Objetivos
<!-- Buscar en el README el Resultado de Aprendizaje con el que se está trabajando -->

## Criterios de Evaluación
<!-- 
    Buscar en el README los criterios de Evaluación con los que se están trabajando.
    Marca con una [X] los conseguidos. Ejemplo:
    [ ] Criterio Evaluación 1.
    [ ] Criterio Evaluación 2.
    [X] Criterio Evaluación 3.
-->